### PR TITLE
Fix clean_path problem (bug if upload dir == '.')

### DIFF
--- a/proxy_storage/utils.py
+++ b/proxy_storage/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
+import os
 
 
 def clean_path(path):
-    return '/{0}'.format(path.strip('/'))
+    return os.path.normpath(os.path.join('/', path))


### PR DESCRIPTION
```
class TestFile(models.Model):
    name = models.CharField(max_length=255, default=get_random_string)
    file = ProxyStorageFileField(storage=storage)
```

We have `ProxyStorageFileField` without `upload_to`.  In this case we can`t find uploaded file =/
